### PR TITLE
Internal distance deviation

### DIFF
--- a/pyvrp/cpp/CostEvaluator.cpp
+++ b/pyvrp/cpp/CostEvaluator.cpp
@@ -6,10 +6,12 @@ using pyvrp::CostEvaluator;
 
 CostEvaluator::CostEvaluator(std::vector<double> loadPenalties,
                              double twPenalty,
-                             double distPenalty)
+                             double distPenalty,
+                             double distDevPenalty)
     : loadPenalties_(std::move(loadPenalties)),
       twPenalty_(twPenalty),
-      distPenalty_(distPenalty)
+      distPenalty_(distPenalty),
+      distDevPenalty_(distDevPenalty)
 {
     for (auto const penalty : loadPenalties_)
         if (penalty < 0)
@@ -20,4 +22,7 @@ CostEvaluator::CostEvaluator(std::vector<double> loadPenalties,
 
     if (distPenalty_ < 0)
         throw std::invalid_argument("dist_penalty must be >= 0.");
+
+    if (distDevPenalty_ < 0)
+        throw std::invalid_argument("dist_dev_penalty must be >= 0.");
 }

--- a/pyvrp/cpp/CostEvaluator.h
+++ b/pyvrp/cpp/CostEvaluator.h
@@ -281,9 +281,13 @@ bool CostEvaluator::deltaCost(Cost &out, T<Args...> const &proposal) const
     out -= route->durationCost();
     out -= twPenalty(route->timeWarp());
 
+    out -= distDevPenalty(route->internalDistance(), route->avgSegmentDistance(), route->numClients());
+
     auto const distance = proposal.distance();
     out += route->unitDistanceCost() * static_cast<Cost>(distance);
     out += distPenalty(distance, route->maxDistance());
+
+    out += distDevPenalty(proposal.route()->internalDistance(), route->avgSegmentDistance(), proposal.route()->numClients());
 
     if constexpr (!exact)
         if (out >= 0)
@@ -321,8 +325,12 @@ bool CostEvaluator::deltaCost(Cost &out,
     out -= uRoute->distanceCost();
     out -= distPenalty(uRoute->distance(), uRoute->maxDistance());
 
+    out -= distDevPenalty(uRoute->internalDistance(), uRoute->avgSegmentDistance(), uRoute->numClients());
+
     out -= vRoute->distanceCost();
     out -= distPenalty(vRoute->distance(), vRoute->maxDistance());
+
+    out -= distDevPenalty(vRoute->internalDistance(), vRoute->avgSegmentDistance(), vRoute->numClients());
 
     if constexpr (!skipLoad)
     {
@@ -340,9 +348,13 @@ bool CostEvaluator::deltaCost(Cost &out,
     out += uRoute->unitDistanceCost() * static_cast<Cost>(uDist);
     out += distPenalty(uDist, uRoute->maxDistance());
 
+    out += distDevPenalty(uProposal.route()->internalDistance(), uRoute->avgSegmentDistance(), uProposal.route()->numClients());
+
     auto const vDist = vProposal.distance();
     out += vRoute->unitDistanceCost() * static_cast<Cost>(vDist);
     out += distPenalty(vDist, vRoute->maxDistance());
+
+    out += distDevPenalty(vProposal.route()->internalDistance(), vRoute->avgSegmentDistance(), vProposal.route()->numClients());
 
     if constexpr (!exact)
         if (out >= 0)

--- a/pyvrp/cpp/CostEvaluator.h
+++ b/pyvrp/cpp/CostEvaluator.h
@@ -90,7 +90,7 @@ public:
     CostEvaluator(std::vector<double> loadPenalties,
                   double twPenalty,
                   double distPenalty,
-                  double distDevPenalty = 1);
+                  double distDevPenalty = 10);
 
     /**
      * Computes the total excess load penalty for the given load and vehicle
@@ -233,7 +233,7 @@ Cost CostEvaluator::distPenalty(Distance distance, Distance maxDistance) const
 
 Cost CostEvaluator::distDevPenalty(Distance internalDistance, Distance avgSegmentDistance, size_t numClients) const
 {
-    auto const distDev = std::max<Distance>(static_cast<double>(internalDistance) - static_cast<double>(avgSegmentDistance) * (numClients - 1), 0);
+    auto const distDev = std::max<Distance>(static_cast<double>(internalDistance) - static_cast<double>(avgSegmentDistance) * (numClients), 0);
     return static_cast<Cost>(distDev.get() * distDevPenalty_);
 }
 

--- a/pyvrp/cpp/CostEvaluator.h
+++ b/pyvrp/cpp/CostEvaluator.h
@@ -90,7 +90,7 @@ public:
     CostEvaluator(std::vector<double> loadPenalties,
                   double twPenalty,
                   double distPenalty,
-                  double distDevPenalty = 0);
+                  double distDevPenalty = 1);
 
     /**
      * Computes the total excess load penalty for the given load and vehicle
@@ -233,7 +233,7 @@ Cost CostEvaluator::distPenalty(Distance distance, Distance maxDistance) const
 
 Cost CostEvaluator::distDevPenalty(Distance internalDistance, Distance avgSegmentDistance, size_t numClients) const
 {
-    auto const distDev = std::max<Distance>(static_cast<double>(internalDistance) - static_cast<double>(avgSegmentDistance) * numClients, 0);
+    auto const distDev = std::max<Distance>(static_cast<double>(internalDistance) - static_cast<double>(avgSegmentDistance) * (numClients - 1), 0);
     return static_cast<Cost>(distDev.get() * distDevPenalty_);
 }
 

--- a/pyvrp/cpp/CostEvaluator.h
+++ b/pyvrp/cpp/CostEvaluator.h
@@ -77,6 +77,7 @@ class CostEvaluator
     std::vector<double> loadPenalties_;  // per load dimension
     double twPenalty_;
     double distPenalty_;
+    double distDevPenalty_;
 
     /**
      * Computes the cost penalty incurred from the given excess loads. This is
@@ -88,7 +89,8 @@ class CostEvaluator
 public:
     CostEvaluator(std::vector<double> loadPenalties,
                   double twPenalty,
-                  double distPenalty);
+                  double distPenalty,
+                  double distDevPenalty = 0);
 
     /**
      * Computes the total excess load penalty for the given load and vehicle
@@ -107,6 +109,13 @@ public:
      */
     [[nodiscard]] inline Cost distPenalty(Distance distance,
                                           Distance maxDistance) const;
+
+    /**
+     * Computes the total distance deviation penalty for the given distance.
+     */
+    [[nodiscard]] inline Cost distDevPenalty(Distance internalDistance,
+                                            Distance avgSegmentDistance,
+                                            size_t numClients) const;
 
     /**
      * Computes a smoothed objective (penalised cost) for a given solution.
@@ -222,6 +231,12 @@ Cost CostEvaluator::distPenalty(Distance distance, Distance maxDistance) const
     return static_cast<Cost>(excessDistance.get() * distPenalty_);
 }
 
+Cost CostEvaluator::distDevPenalty(Distance internalDistance, Distance avgSegmentDistance, size_t numClients) const
+{
+    auto const distDev = std::max<Distance>(static_cast<double>(internalDistance) - static_cast<double>(avgSegmentDistance) * numClients, 0);
+    return static_cast<Cost>(distDev.get() * distDevPenalty_);
+}
+
 template <CostEvaluatable T>
 Cost CostEvaluator::penalisedCost(T const &arg) const
 {
@@ -230,7 +245,8 @@ Cost CostEvaluator::penalisedCost(T const &arg) const
                       + (!arg.empty() ? arg.fixedVehicleCost() : 0)
                       + excessLoadPenalties(arg.excessLoad())
                       + twPenalty(arg.timeWarp())
-                      + distPenalty(arg.excessDistance(), 0);
+                      + distPenalty(arg.excessDistance(), 0)
+                      + distDevPenalty(arg.internalDistance(), arg.avgSegmentDistance(), arg.numClients());
 
     if constexpr (PrizeCostEvaluatable<T>)
         return cost + arg.uncollectedPrizes();

--- a/pyvrp/cpp/ProblemData.cpp
+++ b/pyvrp/cpp/ProblemData.cpp
@@ -446,6 +446,11 @@ std::vector<Matrix<Duration>> const &ProblemData::durationMatrices() const
     return durs_;
 }
 
+Distance ProblemData::avgSegmentDistance() const
+{
+    return avgSegmentDistance_;
+}
+
 ProblemData::ClientGroup const &ProblemData::group(size_t group) const
 {
     assert(group < groups_.size());
@@ -666,6 +671,17 @@ ProblemData::ProblemData(std::vector<Client> clients,
     {
         centroid_.first += static_cast<double>(client.x) / numClients();
         centroid_.second += static_cast<double>(client.y) / numClients();
+    }
+
+    if (numClients() > 1)
+    {
+        Distance totalDistance = 0;
+        for (size_t i = numDepots(); i < numLocations(); ++i)
+            for (size_t j = numDepots(); j < numLocations(); ++j)
+                if (i != j)
+                    totalDistance += dists_[0](i, j);
+        auto const numPairs = static_cast<Distance>(numClients() * (numClients() - 1));
+        avgSegmentDistance_ = totalDistance / numPairs;
     }
 
     validate();

--- a/pyvrp/cpp/ProblemData.cpp
+++ b/pyvrp/cpp/ProblemData.cpp
@@ -451,6 +451,11 @@ Distance ProblemData::avgSegmentDistance() const
     return avgSegmentDistance_;
 }
 
+void ProblemData::setAvgSegmentDistance(Distance avgSegmentDistance)
+{
+    avgSegmentDistance_ = avgSegmentDistance;
+}
+
 ProblemData::ClientGroup const &ProblemData::group(size_t group) const
 {
     assert(group < groups_.size());

--- a/pyvrp/cpp/ProblemData.cpp
+++ b/pyvrp/cpp/ProblemData.cpp
@@ -673,16 +673,5 @@ ProblemData::ProblemData(std::vector<Client> clients,
         centroid_.second += static_cast<double>(client.y) / numClients();
     }
 
-    if (numClients() > 1)
-    {
-        Distance totalDistance = 0;
-        for (size_t i = numDepots(); i < numLocations(); ++i)
-            for (size_t j = numDepots(); j < numLocations(); ++j)
-                if (i != j)
-                    totalDistance += dists_[0](i, j);
-        auto const numPairs = static_cast<Distance>(numClients() * (numClients() - 1));
-        avgSegmentDistance_ = totalDistance / numPairs;
-    }
-
     validate();
 }

--- a/pyvrp/cpp/ProblemData.h
+++ b/pyvrp/cpp/ProblemData.h
@@ -544,7 +544,7 @@ private:
     std::vector<Depot> const depots_;              // Depot information
     std::vector<VehicleType> const vehicleTypes_;  // Vehicle type information
     std::vector<ClientGroup> const groups_;        // Client groups
-    Distance avgSegmentDistance_;           // Average segment distance
+    Distance avgSegmentDistance_;                  // Average segment distance between two clients
 
     size_t const numVehicles_;
     size_t const numLoadDimensions_;
@@ -668,7 +668,7 @@ public:
     durationMatrix(size_t profile) const;
 
     /**
-     * Average segment distance in this problem instance.
+     * Average segment distance between two clients in this problem instance.
      */
     [[nodiscard]] Distance avgSegmentDistance() const;
 

--- a/pyvrp/cpp/ProblemData.h
+++ b/pyvrp/cpp/ProblemData.h
@@ -668,9 +668,14 @@ public:
     durationMatrix(size_t profile) const;
 
     /**
-     * Average segment distance between two clients in this problem instance.
+     * Average segment distance between two clients on actual routes.
      */
     [[nodiscard]] Distance avgSegmentDistance() const;
+
+    /**
+     * Sets the average segment distance between two clients.
+     */
+    void setAvgSegmentDistance(Distance avgSegmentDistance);
 
     /**
      * Number of clients in this problem instance.

--- a/pyvrp/cpp/ProblemData.h
+++ b/pyvrp/cpp/ProblemData.h
@@ -544,6 +544,7 @@ private:
     std::vector<Depot> const depots_;              // Depot information
     std::vector<VehicleType> const vehicleTypes_;  // Vehicle type information
     std::vector<ClientGroup> const groups_;        // Client groups
+    Distance avgSegmentDistance_;           // Average segment distance
 
     size_t const numVehicles_;
     size_t const numLoadDimensions_;
@@ -665,6 +666,11 @@ public:
      */
     [[nodiscard]] inline Matrix<Duration> const &
     durationMatrix(size_t profile) const;
+
+    /**
+     * Average segment distance in this problem instance.
+     */
+    [[nodiscard]] Distance avgSegmentDistance() const;
 
     /**
      * Number of clients in this problem instance.

--- a/pyvrp/cpp/Route.cpp
+++ b/pyvrp/cpp/Route.cpp
@@ -217,12 +217,7 @@ Route::Route(ProblemData const &data, Trips trips, size_t vehType)
         centroid_.second += (y * trip.size()) / size();
     }
 
-    for (size_t i = 0; i < visits().size(); ++i)
-        for (size_t j = i + 1; j < visits().size(); ++j)
-        {
-            auto const &distMat = data.distanceMatrix(vehData.profile);
-            internalDistance_ += distMat(visits()[i], visits()[j]);
-        }
+    internalDistance_ = distance_ - trips_[0].distance() - trips_.back().distance();
 
     distanceCost_ = vehData.unitDistanceCost * static_cast<Cost>(distance_);
     excessDistance_ = std::max<Distance>(distance_ - vehData.maxDistance, 0);
@@ -397,6 +392,8 @@ Duration Route::timeWarp() const { return timeWarp_; }
 Duration Route::waitDuration() const { return duration_ - travel_ - service_; }
 
 Duration Route::travelDuration() const { return travel_; }
+
+Distance Route::internalDistance() const { return internalDistance_; }
 
 Duration Route::startTime() const { return startTime_; }
 

--- a/pyvrp/cpp/Route.cpp
+++ b/pyvrp/cpp/Route.cpp
@@ -225,7 +225,8 @@ Route::Route(ProblemData const &data, Trips trips, size_t vehType)
         if (trip.size() <= 3) {
             continue;
         }
-        internalDistance_ += trip.distance() - distances(trip.startDepot(), trip[0]) - distances(trip[trip.size() - 1], trip.endDepot());
+        internalDistance_ += trip.distance() - distances(trip.startDepot(), trip[0]) - distances(trip[trip.size() - 1], trip.endDepot())
+            + distances(trip[0], trip[trip.size() - 1]);
     }
 
     distanceCost_ = vehData.unitDistanceCost * static_cast<Cost>(distance_);

--- a/pyvrp/cpp/Route.cpp
+++ b/pyvrp/cpp/Route.cpp
@@ -217,7 +217,16 @@ Route::Route(ProblemData const &data, Trips trips, size_t vehType)
         centroid_.second += (y * trip.size()) / size();
     }
 
-    internalDistance_ = distance_ - trips_[0].distance() - trips_.back().distance();
+    auto const &distances = data.distanceMatrix(vehData.profile);
+    internalDistance_ = 0;
+    for (size_t tripIdx = 0; tripIdx != trips_.size(); ++tripIdx)
+    {
+        auto const &trip = trips_[tripIdx];
+        if (trip.size() <= 3) {
+            continue;
+        }
+        internalDistance_ += trip.distance() - distances(trip.startDepot(), trip[0]) - distances(trip[trip.size() - 1], trip.endDepot());
+    }
 
     distanceCost_ = vehData.unitDistanceCost * static_cast<Cost>(distance_);
     excessDistance_ = std::max<Distance>(distance_ - vehData.maxDistance, 0);

--- a/pyvrp/cpp/Route.cpp
+++ b/pyvrp/cpp/Route.cpp
@@ -217,6 +217,13 @@ Route::Route(ProblemData const &data, Trips trips, size_t vehType)
         centroid_.second += (y * trip.size()) / size();
     }
 
+    for (size_t i = 0; i < visits().size(); ++i)
+        for (size_t j = i + 1; j < visits().size(); ++j)
+        {
+            auto const &distMat = data.distanceMatrix(vehData.profile);
+            internalDistance_ += distMat(visits()[i], visits()[j]);
+        }
+
     distanceCost_ = vehData.unitDistanceCost * static_cast<Cost>(distance_);
     excessDistance_ = std::max<Distance>(distance_ - vehData.maxDistance, 0);
 

--- a/pyvrp/cpp/Route.h
+++ b/pyvrp/cpp/Route.h
@@ -237,7 +237,7 @@ public:
     /**
      * Total distance travelled on this route, excluding the first and last segment.
      */
-    [[nodiscard]] Distance internalDistance() const { return internalDistance_; }
+    [[nodiscard]] Distance internalDistance() const;
 
     /**
      * Start time of this route. This is the earliest possible time at which

--- a/pyvrp/cpp/Route.h
+++ b/pyvrp/cpp/Route.h
@@ -123,6 +123,7 @@ private:
     Duration startTime_ = 0;        // (earliest) start time of this route
     Duration slack_ = 0;            // Total time slack on this route
     Cost prizes_ = 0;               // Total value of prizes on this route
+    Distance internalDistance_ = 0; // Total distance travelled on this route, excluding the first and last segment
 
     std::pair<double, double> centroid_;  // Route center
     VehicleType vehicleType_;             // Type of vehicle
@@ -232,6 +233,11 @@ public:
      * Total waiting duration on this route.
      */
     [[nodiscard]] Duration waitDuration() const;
+
+    /**
+     * Total distance travelled on this route, excluding the first and last segment.
+     */
+    [[nodiscard]] Distance internalDistance() const { return internalDistance_; }
 
     /**
      * Start time of this route. This is the earliest possible time at which

--- a/pyvrp/cpp/Solution.cpp
+++ b/pyvrp/cpp/Solution.cpp
@@ -25,6 +25,7 @@ void Solution::evaluate(ProblemData const &data)
         allPrizes += client.prize;
 
     excessLoad_ = std::vector<Load>(data.numLoadDimensions(), 0);
+    avgSegmentDistance_ = data.avgSegmentDistance();
     for (auto const &route : routes_)
     {
         // Whole solution statistics.
@@ -32,6 +33,7 @@ void Solution::evaluate(ProblemData const &data)
         prizes_ += route.prizes();
         distance_ += route.distance();
         distanceCost_ += route.distanceCost();
+        internalDistance_ += route.internalDistance();
         duration_ += route.duration();
         durationCost_ += route.durationCost();
         excessDistance_ += route.excessDistance();
@@ -97,6 +99,10 @@ Distance Solution::distance() const { return distance_; }
 
 Cost Solution::distanceCost() const { return distanceCost_; }
 
+Distance Solution::internalDistance() const { return internalDistance_; }
+
+Distance Solution::avgSegmentDistance() const { return avgSegmentDistance_; }
+
 Duration Solution::duration() const { return duration_; }
 
 Cost Solution::durationCost() const { return durationCost_; }
@@ -134,6 +140,7 @@ bool Solution::operator==(Solution const &other) const
     bool const attributeChecks = distance_ == other.distance_
                               && duration_ == other.duration_
                               && distanceCost_ == other.distanceCost_
+                              && internalDistance_ == other.internalDistance_
                               && durationCost_ == other.durationCost_
                               && timeWarp_ == other.timeWarp_
                               && isGroupFeas_ == other.isGroupFeas_

--- a/pyvrp/cpp/Solution.h
+++ b/pyvrp/cpp/Solution.h
@@ -50,7 +50,7 @@ class Solution
     Distance distance_ = 0;         // Total travel distance over all routes
     Cost distanceCost_ = 0;         // Total cost of all routes' travel distance
     Distance internalDistance_ = 0; // Total distance travelled on all routes, excluding the first and last segments
-    Distance avgSegmentDistance_ = 2; // Average distance travelled on a segment between two clients on actual routes
+    Distance avgSegmentDistance_ = 1.9; // Average distance travelled on a segment between two clients on actual routes
     Duration duration_ = 0;         // Total duration over all routes
     Cost durationCost_ = 0;         // Total cost of all routes' duration
     Distance excessDistance_ = 0;   // Total excess distance over all routes

--- a/pyvrp/cpp/Solution.h
+++ b/pyvrp/cpp/Solution.h
@@ -49,6 +49,8 @@ class Solution
     size_t numMissingClients_ = 0;  // Number of required but missing clients
     Distance distance_ = 0;         // Total travel distance over all routes
     Cost distanceCost_ = 0;         // Total cost of all routes' travel distance
+    Distance internalDistance_ = 0; // Total distance travelled on all routes, excluding the first and last segments
+    Distance avgSegmentDistance_ = 0; // Average distance travelled on a segment between two clients
     Duration duration_ = 0;         // Total duration over all routes
     Cost durationCost_ = 0;         // Total cost of all routes' duration
     Distance excessDistance_ = 0;   // Total excess distance over all routes
@@ -176,6 +178,16 @@ public:
      * Total cost of the distance travelled on routes in this solution.
      */
     [[nodiscard]] Cost distanceCost() const;
+
+    /**
+     * Total distance travelled on all routes, excluding the first and last segments.
+     */
+    [[nodiscard]] Distance internalDistance() const;
+
+    /**
+     * Average distance travelled on a segment between two clients.
+     */
+    [[nodiscard]] Distance avgSegmentDistance() const;
 
     /**
      * Total duration of all routes in this solution.

--- a/pyvrp/cpp/Solution.h
+++ b/pyvrp/cpp/Solution.h
@@ -50,7 +50,7 @@ class Solution
     Distance distance_ = 0;         // Total travel distance over all routes
     Cost distanceCost_ = 0;         // Total cost of all routes' travel distance
     Distance internalDistance_ = 0; // Total distance travelled on all routes, excluding the first and last segments
-    Distance avgSegmentDistance_ = 1.9; // Average distance travelled on a segment between two clients on actual routes
+    Distance avgSegmentDistance_ = 0; // Average distance travelled on a segment between two clients on actual routes
     Duration duration_ = 0;         // Total duration over all routes
     Cost durationCost_ = 0;         // Total cost of all routes' duration
     Distance excessDistance_ = 0;   // Total excess distance over all routes

--- a/pyvrp/cpp/Solution.h
+++ b/pyvrp/cpp/Solution.h
@@ -50,7 +50,7 @@ class Solution
     Distance distance_ = 0;         // Total travel distance over all routes
     Cost distanceCost_ = 0;         // Total cost of all routes' travel distance
     Distance internalDistance_ = 0; // Total distance travelled on all routes, excluding the first and last segments
-    Distance avgSegmentDistance_ = 0; // Average distance travelled on a segment between two clients
+    Distance avgSegmentDistance_ = 2; // Average distance travelled on a segment between two clients on actual routes
     Duration duration_ = 0;         // Total duration over all routes
     Cost durationCost_ = 0;         // Total cost of all routes' duration
     Distance excessDistance_ = 0;   // Total excess distance over all routes

--- a/pyvrp/cpp/bindings.cpp
+++ b/pyvrp/cpp/bindings.cpp
@@ -446,6 +446,12 @@ PYBIND11_MODULE(_pyvrp, m)
              &ProblemData::durationMatrices,
              py::return_value_policy::reference_internal,
              DOC(pyvrp, ProblemData, durationMatrices))
+        .def("avg_segment_distance",
+             &ProblemData::avgSegmentDistance,
+             DOC(pyvrp, ProblemData, avgSegmentDistance))
+        .def("set_avg_segment_distance",
+             &ProblemData::setAvgSegmentDistance,
+             py::arg("avg_segment_distance"))
         .def("centroid",
              &ProblemData::centroid,
              py::return_value_policy::reference_internal,

--- a/pyvrp/cpp/search/Route.cpp
+++ b/pyvrp/cpp/search/Route.cpp
@@ -68,7 +68,8 @@ Route::Route(ProblemData const &data, size_t idx, size_t vehicleType)
       loadAfter(data.numLoadDimensions()),
       loadBefore(data.numLoadDimensions()),
       load_(data.numLoadDimensions()),
-      excessLoad_(data.numLoadDimensions())
+      excessLoad_(data.numLoadDimensions()),
+      avgSegmentDistance_(data.avgSegmentDistance())
 {
     clear();
 }

--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -830,7 +830,9 @@ Cost Route::unitDistanceCost() const { return vehicleType_.unitDistanceCost; }
 
 Distance Route::internalDistance() const {
     assert(!dirty);
-    return cumDist[size() - 1] - cumDist[0];
+    if (size() <= 3)
+        return 0;
+    return cumDist[size() - 2] - cumDist[1];
 }
 
 Distance Route::avgSegmentDistance() const { return avgSegmentDistance_; }

--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -297,6 +297,8 @@ private:
     std::vector<DurationSegment> durAfter;   // Dur of node -> end (incl.)
     std::vector<DurationSegment> durBefore;  // Dur of start -> node (incl.)
 
+    Distance avgSegmentDistance_ = 0; // Average distance travelled on a segment between two clients
+
 #ifndef NDEBUG
     // When debug assertions are enabled, we use this flag to check whether
     // the statistics are still in sync with the route's nodes list. Statistics
@@ -400,6 +402,16 @@ public:
      * @return Cost per unit of distance travelled on this route.
      */
     [[nodiscard]] inline Cost unitDistanceCost() const;
+
+    /**
+     * @return Total distance travelled on this route, excluding the first and last segments.
+     */
+    [[nodiscard]] inline Distance internalDistance() const;
+
+    /**
+     * @return Average distance travelled on a segment between two clients.
+     */
+    [[nodiscard]] inline Distance avgSegmentDistance() const;
 
     /**
      * @return The duration of this route.
@@ -815,6 +827,13 @@ Cost Route::distanceCost() const
 }
 
 Cost Route::unitDistanceCost() const { return vehicleType_.unitDistanceCost; }
+
+Distance Route::internalDistance() const {
+    assert(!dirty);
+    return cumDist[size() - 1] - cumDist[0];
+}
+
+Distance Route::avgSegmentDistance() const { return avgSegmentDistance_; }
 
 Duration Route::duration() const
 {


### PR DESCRIPTION
This PR:

- Implements the suggestion from [this comment](https://github.com/PyVRP/PyVRP/issues/822#issuecomment-2915670573). It generates more clustered routes.
- Adds the distance from the first to the last client. This accounts for cases where closed clients may require a return visit, making circular-like solutions more suitable for the business case.
- Instead of the suggested computation of the average segment duration between clients, it receives an input parameter. In tests with real-world instances, the computed average (based on the instance itself) was consistently too large. The used input is derived from the average segment duration observed in historical real routes.