### PR TITLE
Parameterize distDevPenalty

### DIFF
--- a/pyvrp/Model.py
+++ b/pyvrp/Model.py
@@ -345,6 +345,23 @@ class Model:
 
         self._avg_segment_distance = int(distance) if distance is not None else None
 
+    def set_dist_dev_penalty(self, penalty: float | None) -> None:
+        """Sets the distance deviation penalty for the model.
+        The distance deviation is calculated as the difference between:
+
+        - the product of the average segment distance and the number of clients in the route, and
+
+        - the total internal distance of the route (excluding depot trips), which includes the distances between consecutive clients and the segment from the first to the last client.
+
+        Parameters
+        ----------
+        penalty
+            The penalty value to set. Provide ``None`` to unset.
+        """
+        if penalty is not None and penalty < 0:
+            raise ValueError("Distance deviation penalty must be non-negative.")
+        self._dist_dev_penalty = penalty
+
     def add_vehicle_type(
         self,
         num_available: int = 1,
@@ -500,6 +517,17 @@ class Model:
                 # Linked _pyvrp version does not expose the setter.
                 warn(
                     "avg_segment_distance could not be set – _pyvrp is out of date.",
+                    RuntimeWarning,
+                )
+
+        # Propagate user-defined distance deviation penalty to ProblemData.
+        if self._dist_dev_penalty is not None:
+            try:
+                pdata.set_dist_dev_penalty(self._dist_dev_penalty)
+            except AttributeError:
+                # Linked _pyvrp version does not expose the setter.
+                warn(
+                    "dist_dev_penalty could not be set – _pyvrp is out of date.",
                     RuntimeWarning,
                 )
 

--- a/pyvrp/PenaltyManager.py
+++ b/pyvrp/PenaltyManager.py
@@ -55,6 +55,8 @@ class PenaltyParams:
         Minimum penalty term value. Must not be negative.
     max_penalty
         Maximum penalty term value. Must not be negative.
+    dist_dev_penalty
+        Distance deviation penalty. Must not be negative.
 
         .. warning::
            Setting a (too) large maximum penalty value may cause integer
@@ -84,6 +86,8 @@ class PenaltyParams:
         Minimum penalty term value.
     max_penalty
         Maximum penalty term value.
+    dist_dev_penalty
+        Distance deviation penalty.
     """
 
     repair_booster: int = 12
@@ -94,6 +98,7 @@ class PenaltyParams:
     feas_tolerance: float = 0.05
     min_penalty: float = 0.1
     max_penalty: float = 100_000.0
+    dist_dev_penalty: float = 0.0
 
     def __post_init__(self):
         if not self.repair_booster >= 1:
@@ -119,6 +124,9 @@ class PenaltyParams:
 
         if self.max_penalty < self.min_penalty:
             raise ValueError("Expected max_penalty >= min_penalty.")
+
+        if self.dist_dev_penalty < -1e-6:
+            raise ValueError("Expected dist_dev_penalty >= 0.")
 
 
 class PenaltyManager:
@@ -229,6 +237,7 @@ class PenaltyManager:
         init_load = avg_cost / np.maximum(avg_load, 1)
         init_tw = avg_cost / max(avg_duration, 1)
         init_dist = avg_cost / max(avg_distance, 1)
+        params.dist_dev_penalty = data.dist_dev_penalty()
         return cls((init_load.tolist(), init_tw, init_dist), params)
 
     def _compute(self, penalty: float, feas_percentage: float) -> float:
@@ -290,11 +299,11 @@ class PenaltyManager:
         Get a cost evaluator using the current penalty values.
         """
         *loads, tw, dist = self._penalties
-        return CostEvaluator(loads, tw, dist)
+        return CostEvaluator(loads, tw, dist, self._params.dist_dev_penalty)
 
     def booster_cost_evaluator(self) -> CostEvaluator:
         """
         Get a cost evaluator using the boosted current penalty values.
         """
         *loads, tw, dist = self._penalties * self._params.repair_booster
-        return CostEvaluator(loads, tw, dist)
+        return CostEvaluator(loads, tw, dist, self._params.dist_dev_penalty)

--- a/pyvrp/cpp/CostEvaluator.h
+++ b/pyvrp/cpp/CostEvaluator.h
@@ -90,7 +90,7 @@ public:
     CostEvaluator(std::vector<double> loadPenalties,
                   double twPenalty,
                   double distPenalty,
-                  double distDevPenalty = 10);
+                  double distDevPenalty = 0);
 
     /**
      * Computes the total excess load penalty for the given load and vehicle

--- a/pyvrp/cpp/ProblemData.cpp
+++ b/pyvrp/cpp/ProblemData.cpp
@@ -456,6 +456,15 @@ void ProblemData::setAvgSegmentDistance(Distance avgSegmentDistance)
     avgSegmentDistance_ = avgSegmentDistance;
 }
 
+double ProblemData::distDevPenalty() const
+{
+    return distDevPenalty_;
+}
+void ProblemData::setDistDevPenalty(double distDevPenalty)
+{
+    distDevPenalty_ = distDevPenalty;
+}
+
 ProblemData::ClientGroup const &ProblemData::group(size_t group) const
 {
     assert(group < groups_.size());

--- a/pyvrp/cpp/ProblemData.h
+++ b/pyvrp/cpp/ProblemData.h
@@ -545,6 +545,7 @@ private:
     std::vector<VehicleType> const vehicleTypes_;  // Vehicle type information
     std::vector<ClientGroup> const groups_;        // Client groups
     Distance avgSegmentDistance_;                  // Average segment distance between two clients
+    double distDevPenalty_;                         // Distance deviation penalty for the model
 
     size_t const numVehicles_;
     size_t const numLoadDimensions_;
@@ -676,6 +677,16 @@ public:
      * Sets the average segment distance between two clients.
      */
     void setAvgSegmentDistance(Distance avgSegmentDistance);
+
+    /**
+     * Distance deviation penalty for the model.
+     */
+    [[nodiscard]] double distDevPenalty() const;
+
+    /**
+     * Sets the distance deviation penalty for the model.
+     */
+    void setDistDevPenalty(double distDevPenalty);
 
     /**
      * Number of clients in this problem instance.

--- a/pyvrp/cpp/bindings.cpp
+++ b/pyvrp/cpp/bindings.cpp
@@ -452,6 +452,12 @@ PYBIND11_MODULE(_pyvrp, m)
         .def("set_avg_segment_distance",
              &ProblemData::setAvgSegmentDistance,
              py::arg("avg_segment_distance"))
+        .def("dist_dev_penalty",
+             &ProblemData::distDevPenalty,
+             DOC(pyvrp, ProblemData, distDevPenalty))
+        .def("set_dist_dev_penalty",
+             &ProblemData::setDistDevPenalty,
+             py::arg("dist_dev_penalty"))
         .def("centroid",
              &ProblemData::centroid,
              py::return_value_policy::reference_internal,
@@ -944,10 +950,11 @@ PYBIND11_MODULE(_pyvrp, m)
              });
 
     py::class_<CostEvaluator>(m, "CostEvaluator", DOC(pyvrp, CostEvaluator))
-        .def(py::init<std::vector<double>, double, double>(),
+        .def(py::init<std::vector<double>, double, double, double>(),
              py::arg("load_penalties"),
              py::arg("tw_penalty"),
-             py::arg("dist_penalty"))
+             py::arg("dist_penalty"),
+             py::arg("dist_dev_penalty"))
         .def("load_penalty",
              &CostEvaluator::loadPenalty,
              py::arg("load"),
@@ -963,6 +970,12 @@ PYBIND11_MODULE(_pyvrp, m)
              py::arg("distance"),
              py::arg("max_distance"),
              DOC(pyvrp, CostEvaluator, distPenalty))
+        .def("dist_dev_penalty",
+             &CostEvaluator::distDevPenalty,
+             py::arg("internal_distance"),
+             py::arg("avg_segment_distance"),
+             py::arg("num_clients"),
+             DOC(pyvrp, CostEvaluator, distDevPenalty))
         .def("penalised_cost",
              &CostEvaluator::penalisedCost<Solution>,
              py::arg("solution"),


### PR DESCRIPTION
This PR:

- Sets the default value of `distDevPenalty` to 0;

- Adds a setter method for `distDevPenalty` (`Model.set_dist_dev_penalty(self, penalty: float | None)`).